### PR TITLE
Fixed compression type detection

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -142,7 +142,7 @@ Archive.prototype = {
         return void callback.call( this, error )
       }
 
-      if( ( folder.compressionType & 0x0F ) !== Cabinet.COMPRESSION.NONE ) {
+      if( ( folder.compressionType & 0xFF ) !== Cabinet.COMPRESSION.NONE ) {
         return void callback.call( this, new Error( `Compression not supported` ) )
       }
 

--- a/lib/archive.js
+++ b/lib/archive.js
@@ -142,7 +142,7 @@ Archive.prototype = {
         return void callback.call( this, error )
       }
 
-      if( ( folder.compressionType & 0xFF00 ) !== Cabinet.COMPRESSION.NONE ) {
+      if( ( folder.compressionType & 0x0F ) !== Cabinet.COMPRESSION.NONE ) {
         return void callback.call( this, new Error( `Compression not supported` ) )
       }
 

--- a/lib/cabinet.js
+++ b/lib/cabinet.js
@@ -10,14 +10,14 @@ Cabinet.SIGNATURE = 0x4643534D
 Cabinet.MSZIP_SIGNATURE = 0x4B43
 
 Cabinet.COMPRESSION = {
-  NONE: 0x0000,
-  MSZIP: 0x0100,
-  QUANTUM: 0x0200,
-  LZX: 0x0300,
+  NONE: 0,
+  MSZIP: 1,
+  QUANTUM: 2,
+  LZX: 3
   // NOTE: High 8 bits store compression extra
   // (for LZX the value between 15-21 [0x0F-0x15])
-  // LZX21: 0x0315,
-  // LZX15: 0x030F,
+  // LZX21: 0x1503,
+  // LZX15: 0x150F,
 }
 
 Cabinet.checksum = require( './checksum' )

--- a/lib/cabinet.js
+++ b/lib/cabinet.js
@@ -17,7 +17,7 @@ Cabinet.COMPRESSION = {
   // NOTE: High 8 bits store compression extra
   // (for LZX the value between 15-21 [0x0F-0x15])
   // LZX21: 0x1503,
-  // LZX15: 0x150F,
+  // LZX15: 0x0F03,
 }
 
 Cabinet.checksum = require( './checksum' )


### PR DESCRIPTION
Comparing against [other working implementations](https://github.com/incbee/Unarchiver/blob/28a2330b16139f6d074cdf75ea34eee0ccd218c4/XADMaster/XADCABParser.m), we can see that compression type detection was broken in node-cabarc and would only detect LZX compression.